### PR TITLE
pyxattr build fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'pexpect>=4.7.0',
         #'psutil',
         'python-dateutil',
-        "pyxattr; os_name != 'nt'",
+        # "pyxattr; os_name != 'nt'",
         'terminaltables',
         #'Xlib',
     ],


### PR DESCRIPTION
Package will not work for Python 3.8. Is this library being used still in this repo?